### PR TITLE
Add UsersTableSeeder with example admin user

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,11 +2,7 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
-use App\Models\Participant;
-use App\Models\Race;
-use App\Models\Registration;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,12 +11,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        Race::factory()->count(2)->create(); // 2 races: 5K and 10K
-        Participant::factory()->count(50)->create()->each(function ($participant) {
-            Registration::factory()->create([
-                'participant_id' => $participant->id,
-                'race_id' => Race::inRandomOrder()->first()->id,
-            ]);
-        });
+        $this->call([
+            RegistrationsSeeder::class,
+            UsersTableSeeder::class
+        ]);
     }
 }

--- a/database/seeders/RegistrationsSeeder.php
+++ b/database/seeders/RegistrationsSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\Models\Participant;
+use App\Models\Race;
+use App\Models\Registration;
+
+class RegistrationsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Race::factory()->count(2)->create(); // 2 races: 5K and 10K
+        Participant::factory()->count(50)->create()->each(function ($participant) {
+            Registration::factory()->create([
+                'participant_id' => $participant->id,
+                'race_id' => Race::inRandomOrder()->first()->id,
+            ]);
+        });
+    }
+}

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class UsersTableSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::create([
+            'name' => 'Curotec Admin',
+            'email' => 'admin@curotec.com',
+            'password' => Hash::make('passwordCuro123'),
+            'email_verified_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a seeder to create a default admin user in the database for development purposes.

Changes included:
- UsersTableSeeder.php creates an admin user.
- Registered the seeder in DatabaseSeeder.php.
- Developers can now run `php artisan db:seed` to populate the database with an admin account.

